### PR TITLE
Add onboarding wizard and backend logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# buchmann
+# PflegeForge
+
+This repository provides a starter monorepo for building the onboarding service described in the project outline. It relies on Next.js with Turborepo and integrates Supabase, Stripe, Twilio, Resend and OpenAI.
+
+## Structure
+
+- `apps/web` – customer facing Next.js app with an onboarding wizard
+- `apps/api` – Next.js API routes (webhooks, cron jobs)
+- `packages/db` – shared TypeScript types for the Supabase schema
+- `packages/ai` – wrapper for OpenAI calls
+
+Install dependencies locally and run all apps with Turborepo:
+
+```bash
+pnpm install
+pnpm turbo run dev
+```
+
+The web app offers a login with Google and a simple multi-step wizard. Form data is saved via server actions to Supabase with `status = draft` until payment succeeds. Stripe webhooks update the payment table and set the case status to `pending`.

--- a/apps/api/next.config.js
+++ b/apps/api/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "api",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/apps/api/src/routes/reminders.ts
+++ b/apps/api/src/routes/reminders.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function GET() {
+  const supabase = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+  const { data: cases } = await supabase
+    .from('cases')
+    .select('id,user_id,status')
+    .not('status', 'eq', 'complete');
+
+  for (const c of cases ?? []) {
+    // send a reminder email (placeholder)
+    await resend.emails.send({
+      to: 'user@example.com',
+      subject: 'Dokumente fehlen',
+      html: `<p>Bitte laden Sie fehlende Dokumente zu Fall ${c.id} hoch.</p>`,
+      from: 'noreply@example.com'
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/api/src/routes/resend-email.ts
+++ b/apps/api/src/routes/resend-email.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST(req: NextRequest) {
+  const { to, subject, html } = await req.json();
+  await resend.emails.send({ to, subject, html, from: 'noreply@example.com' });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/api/src/routes/signrequest-webhook.ts
+++ b/apps/api/src/routes/signrequest-webhook.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const caseId = body.metadata?.case_id;
+  const pdfUrl = body.pdf_url;
+
+  const supabase = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+  if (caseId && pdfUrl) {
+    await supabase.from('documents').insert({
+      case_id: caseId,
+      type: 'power_of_attorney',
+      storage_url: pdfUrl,
+      uploaded_at: new Date().toISOString()
+    });
+    await supabase.from('cases').update({ signed_power_of_attorney_url: pdfUrl }).eq('id', caseId);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/api/src/routes/stripe-webhook.ts
+++ b/apps/api/src/routes/stripe-webhook.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { createServerClient } from '@supabase/ssr';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2022-11-15' });
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text();
+  const sig = req.headers.get('stripe-signature') || '';
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(payload, sig, process.env.STRIPE_WEBHOOK_SECRET || '');
+  } catch (err) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  const supabase = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const caseId = session.metadata?.case_id;
+    if (caseId) {
+      await supabase.from('payments').insert({
+        case_id: caseId,
+        stripe_payment_intent: session.payment_intent as string,
+        amount: session.amount_total || 0,
+        status: 'paid'
+      });
+      await supabase.from('cases').update({ status: 'pending' }).eq('id', caseId);
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/apps/api/src/routes/twilio-sms.ts
+++ b/apps/api/src/routes/twilio-sms.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import twilio from 'twilio';
+
+const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  await client.messages.create({
+    body: data.message,
+    from: process.env.TWILIO_PHONE_NUMBER!,
+    to: data.to
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,11 @@
+import { AuthProvider } from '../providers/auth';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useAuth } from '../../providers/auth';
+
+export default function LoginPage() {
+  const { signIn } = useAuth();
+  return (
+    <div className="p-4">
+      <button onClick={signIn} className="px-4 py-2 bg-blue-500 text-white">Login with Google</button>
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import Link from 'next/link';
+import { useAuth } from '../providers/auth';
+
+export default function Page() {
+  const { user, signIn, signOut } = useAuth();
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">PflegeForge</h1>
+      {user ? (
+        <>
+          <p>Angemeldet als {user.email}</p>
+          <Link href="/wizard" className="underline">Wizard starten</Link>
+          <button onClick={signOut} className="ml-4 text-sm underline">Logout</button>
+        </>
+      ) : (
+        <button onClick={signIn} className="px-4 py-2 bg-blue-500 text-white">Login mit Google</button>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/wizard/actions.ts
+++ b/apps/web/app/wizard/actions.ts
@@ -1,0 +1,17 @@
+'use server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export async function saveStep(step: number, data: any) {
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { cookies }
+  );
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('not authenticated');
+
+  const updates = { user_id: user.id, ...data, status: 'draft' };
+  await supabase.from('cases').upsert(updates, { onConflict: 'user_id' });
+}

--- a/apps/web/app/wizard/page.tsx
+++ b/apps/web/app/wizard/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useState } from 'react';
+import { saveStep } from './actions';
+
+export default function WizardPage() {
+  const [step, setStep] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const data = Object.fromEntries(formData.entries());
+    setLoading(true);
+    await saveStep(step, data);
+    setLoading(false);
+    setStep(step + 1);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Onboarding Wizard</h1>
+      {step === 1 && (
+        <form onSubmit={onSubmit} className="space-y-2">
+          <input name="first_name" placeholder="Vorname" className="border p-2" />
+          <input name="last_name" placeholder="Nachname" className="border p-2" />
+          <button className="px-4 py-2 bg-blue-500 text-white" disabled={loading}>
+            Weiter
+          </button>
+        </form>
+      )}
+      {step === 2 && (
+        <form onSubmit={onSubmit} className="space-y-2">
+          <input name="kasse" placeholder="Krankenkasse" className="border p-2" />
+          <button className="px-4 py-2 bg-blue-500 text-white" disabled={loading}>
+            Weiter
+          </button>
+        </form>
+      )}
+      {step === 3 && <p>Vielen Dank! Weitere Schritte folgen.</p>}
+    </div>
+  );
+}

--- a/apps/web/lib/supabaseClient.ts
+++ b/apps/web/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createBrowserClient } from '@supabase/ssr';
+
+export const supabase = createBrowserClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/apps/web/providers/auth.tsx
+++ b/apps/web/providers/auth.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import type { User } from '@supabase/supabase-js';
+
+interface AuthContextValue {
+  user: User | null;
+  signIn: () => void;
+  signOut: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  signIn: () => {},
+  signOut: () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user ?? null));
+    const { data: listener } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => listener.subscription.unsubscribe();
+  }, []);
+
+  const signIn = () => supabase.auth.signInWithOAuth({ provider: 'google' });
+  const signOut = () => supabase.auth.signOut();
+
+  return (
+    <AuthContext.Provider value={{ user, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "pflegeforge",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev": "turbo run dev --parallel",
+    "build": "turbo run build",
+    "start": "turbo run start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "^2.39.0",
+    "@supabase/ssr": "^0.2.2",
+    "stripe": "^12.15.0",
+    "twilio": "^4.15.0",
+    "resend": "^0.2.0",
+    "openai": "^4.27.0"
+  },
+  "devDependencies": {
+    "turbo": "^1.11.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pflegeforge/ai",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,0 +1,11 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI();
+
+export async function complete(prompt: string) {
+  const response = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model: 'gpt-3.5-turbo'
+  });
+  return response.choices[0]?.message.content ?? '';
+}

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pflegeforge/db",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,40 @@
+export type User = {
+  id: string;
+  email: string;
+  role: 'client' | 'admin';
+  stripe_customer_id: string | null;
+};
+
+export type Case = {
+  id: string;
+  user_id: string;
+  pflegegrad_target: number | null;
+  kasse: string | null;
+  status: 'draft' | 'pending' | 'md-scheduled' | 'complete';
+  md_date?: string | null;
+  signed_power_of_attorney_url?: string | null;
+};
+
+export type Payment = {
+  id: string;
+  case_id: string;
+  stripe_payment_intent: string;
+  amount: number;
+  status: 'pending' | 'paid' | 'failed';
+};
+
+export type Document = {
+  id: string;
+  case_id: string;
+  type: 'power_of_attorney' | 'pdf_application' | 'md_report';
+  storage_url: string;
+  uploaded_at: string;
+};
+
+export type Appointment = {
+  id: string;
+  case_id: string;
+  kind: 'mdk' | 'prep_call';
+  starts_at: string;
+  channel: string;
+};

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["apps/**/*", "packages/**/*"]
+}


### PR DESCRIPTION
## Summary
- document monorepo structure and workflow in README
- implement AuthProvider and login page
- create multi-step onboarding wizard saving steps to Supabase
- add Stripe and SignRequest webhook handlers and reminders route
- extend database type definitions

## Testing
- `npm run build` *(fails: turbo not found)*
- `git status --short`