### PR TITLE
Initialize Turborepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# buchmann
+# PflegeForge
+
+This repository provides a minimal monorepo skeleton for the platform described in the project plan. It uses Next.js with Turborepo, Supabase, Stripe, Twilio, Resend and OpenAI.
+
+The project structure:
+
+- `apps/web` – Next.js 14 frontend
+- `apps/api` – API routes and webhooks
+- `packages/db` – database types and utilities
+- `packages/ai` – wrapper for OpenAI
+
+The root `package.json` defines workspaces for each app and package. Dependency installation requires network access which is not available in this environment, so you will need to run `pnpm install` locally.
+
+## Development
+
+```bash
+pnpm install
+pnpm turbo run dev
+```

--- a/apps/api/next.config.js
+++ b/apps/api/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "api",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/apps/api/src/routes/resend-email.ts
+++ b/apps/api/src/routes/resend-email.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST(req: NextRequest) {
+  const { to, subject, html } = await req.json();
+  await resend.emails.send({ to, subject, html, from: 'noreply@example.com' });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/api/src/routes/stripe-webhook.ts
+++ b/apps/api/src/routes/stripe-webhook.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2022-11-15' });
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text();
+  const sig = req.headers.get('stripe-signature') || '';
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(payload, sig, process.env.STRIPE_WEBHOOK_SECRET || '');
+  } catch (err) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  // handle event
+  console.log('Stripe event', event.type);
+
+  return NextResponse.json({ received: true });
+}

--- a/apps/api/src/routes/twilio-sms.ts
+++ b/apps/api/src/routes/twilio-sms.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import twilio from 'twilio';
+
+const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  await client.messages.create({
+    body: data.message,
+    from: process.env.TWILIO_PHONE_NUMBER!,
+    to: data.to
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">PflegeForge</h1>
+      <p>Welcome to your Next.js app.</p>
+    </main>
+  );
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "pflegeforge",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev": "turbo run dev --parallel",
+    "build": "turbo run build",
+    "start": "turbo run start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "^2.39.0",
+    "@supabase/ssr": "^0.6.1",
+    "stripe": "^12.15.0",
+    "twilio": "^4.15.0",
+    "resend": "^0.2.0",
+    "openai": "^4.27.0"
+  },
+  "devDependencies": {
+    "turbo": "^1.11.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pflegeforge/ai",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,0 +1,11 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI();
+
+export async function complete(prompt: string) {
+  const response = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model: 'gpt-3.5-turbo'
+  });
+  return response.choices[0]?.message.content ?? '';
+}

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pflegeforge/db",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,10 @@
+export type User = {
+  id: string;
+  email: string;
+};
+
+export type Case = {
+  id: string;
+  userId: string;
+  status: 'draft' | 'pending' | 'closed';
+};

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["apps/**/*", "packages/**/*"]
+}


### PR DESCRIPTION
## Summary
- set up monorepo using workspaces
- add placeholder Next.js apps for `web` and `api`
- add OpenAI and database package scaffolding
- include example webhook handlers for Stripe and Twilio
- document usage in README
- update `@supabase/ssr` to a valid version

## Testing
- `npm run build` *(fails: `turbo` not found)*